### PR TITLE
Localdev: add `docker-compose`

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: "3.1"
+services:
+  mongodb:
+    image: mongo:6
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: blobscan
+      MONGO_INITDB_ROOT_PASSWORD: blob4844
+    volumes:
+      - ~/.blobscan/mongodb:/data/db
+    ports:
+      - "27017:27017"
+    networks:
+      - blobscan
+networks:
+  blobscan:
+    driver: bridge


### PR DESCRIPTION
Adds a `docker-compose` file to quickly spin up a persistent mongodb instance. After doing this and #7, getting started locally should be just `docker compose up` and cloning `.env.example` as `.env`, and adding the relevant execution/beacon node rpcs.