### PR TITLE
Handle reorgs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -328,6 +328,7 @@ dependencies = [
  "jsonwebtoken",
  "log",
  "reqwest",
+ "reqwest-eventsource",
  "sentry",
  "sentry-tracing",
  "serde",
@@ -1139,6 +1140,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "eventsource-stream"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74fef4569247a5f429d9156b9d0a2599914385dd189c539334c625d8099d90ab"
+dependencies = [
+ "futures-core",
+ "nom",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "eyre"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1834,6 +1846,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1870,6 +1888,16 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -2392,6 +2420,7 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tokio-rustls",
+ "tokio-util",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -2399,6 +2428,22 @@ dependencies = [
  "web-sys",
  "webpki-roots",
  "winreg",
+]
+
+[[package]]
+name = "reqwest-eventsource"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f529a5ff327743addc322af460761dff5b50e0c826b9e6ac44c3195c50bb2026"
+dependencies = [
+ "eventsource-stream",
+ "futures-core",
+ "futures-timer",
+ "mime",
+ "nom",
+ "pin-project-lite",
+ "reqwest",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ ethers = "1.0.2"
 futures = "0.3.25"
 hex = "0.4.3"
 reqwest = { version = "0.11.13", features = ["json"] }
+reqwest-eventsource = "0.5.0"
 url = { version = "2.3.1", features = ["serde"] }
 serde = { version = "1.0.150", features = ["derive"] }
 tokio = { version = "1.23.0", features = ["full"] }

--- a/src/chain_reorg_handler/mod.rs
+++ b/src/chain_reorg_handler/mod.rs
@@ -1,0 +1,77 @@
+use anyhow::Result;
+use futures::StreamExt;
+use reqwest_eventsource::Event;
+use tokio::task::JoinHandle;
+use tracing::{debug, error};
+
+use crate::{
+    clients::beacon::types::{ChainReorgResponse, Topic},
+    context::Context,
+};
+
+pub struct ChainReorgHandler {
+    context: Context,
+}
+
+impl ChainReorgHandler {
+    pub fn new(context: Context) -> ChainReorgHandler {
+        Self { context }
+    }
+
+    pub fn run(&self) -> Result<JoinHandle<Result<(), anyhow::Error>>> {
+        let thread_context = self.context.clone();
+
+        let handle = tokio::spawn(async move {
+            let blobscan_client = thread_context.blobscan_client();
+            let beacon_client = thread_context.beacon_client();
+            let mut event_source = match beacon_client.subscribe_to_events(vec![Topic::ChainReorg])
+            {
+                Ok(es) => es,
+                Err(error) => {
+                    error!(
+                        target = "chain_reorg_handler",
+                        ?error,
+                        "Failed to subscribe to chain reorg events"
+                    );
+
+                    return Err(error.into());
+                }
+            };
+
+            while let Some(event) = event_source.next().await {
+                match event {
+                    Ok(Event::Open) => debug!(
+                        target = "chain_reorg_handler",
+                        "Listening to chain reorg events…"
+                    ),
+                    Ok(Event::Message(message)) => {
+                        let chain_reorg_data =
+                            serde_json::from_str::<ChainReorgResponse>(&message.data)?;
+
+                        let new_head_slot = chain_reorg_data.slot.parse::<u32>()?;
+                        let reorg_depth = chain_reorg_data.depth.parse::<u32>()?;
+
+                        blobscan_client
+                            .handle_reorg(new_head_slot, reorg_depth)
+                            .await?;
+                    }
+                    Err(e) => {
+                        error!(
+                            target = "chain_reorg_handler",
+                            ?e,
+                            "Failed to receive chain reorg event"
+                        );
+
+                        event_source.close();
+
+                        return Err(e.into());
+                    }
+                }
+            }
+
+            Ok(())
+        });
+
+        Ok(handle)
+    }
+}

--- a/src/clients/beacon/mod.rs
+++ b/src/clients/beacon/mod.rs
@@ -1,10 +1,11 @@
 use anyhow::Context as AnyhowContext;
 use reqwest::{Client, Url};
+use reqwest_eventsource::EventSource;
 use std::time::Duration;
 
 use crate::{clients::common::ClientResult, json_get};
 
-use self::types::{Blob, BlobsResponse, BlockMessage as Block, BlockResponse};
+use self::types::{Blob, BlobsResponse, BlockMessage as Block, BlockResponse, Topic};
 
 pub mod types;
 
@@ -49,5 +50,19 @@ impl BeaconClient {
             Some(r) => Some(r.data),
             None => None,
         })
+    }
+
+    pub fn subscribe_to_events(&self, topics: Vec<Topic>) -> ClientResult<EventSource> {
+        let topics = topics
+            .iter()
+            .map(|topic| topic.to_string())
+            .collect::<Vec<String>>()
+            .join("&");
+        let path = format!("v1/events?topics={topics}");
+        let url = self.base_url.join(&path)?;
+
+        let event_source = EventSource::get(url);
+
+        Ok(event_source)
     }
 }

--- a/src/clients/beacon/types.rs
+++ b/src/clients/beacon/types.rs
@@ -1,6 +1,18 @@
 use ethers::types::{Bytes, H256};
 use serde::Deserialize;
 
+pub enum Topic {
+    ChainReorg,
+}
+
+impl Topic {
+    pub fn to_string(&self) -> String {
+        match self {
+            Topic::ChainReorg => String::from("chain_reorg"),
+        }
+    }
+}
+
 #[derive(Deserialize, Debug)]
 pub struct ExecutionPayload {
     pub block_hash: H256,
@@ -37,4 +49,12 @@ pub struct Blob {
 #[derive(Deserialize, Debug)]
 pub struct BlobsResponse {
     pub data: Vec<Blob>,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct ChainReorgResponse {
+    pub slot: String,
+    pub depth: String,
+    pub old_head_block: String,
+    pub new_head_block: String,
 }

--- a/src/clients/blobscan/mod.rs
+++ b/src/clients/blobscan/mod.rs
@@ -6,7 +6,7 @@ use crate::{clients::common::ClientResult, json_get, json_put};
 
 use self::{
     jwt_manager::{Config as JWTManagerConfig, JWTManager},
-    types::{Blob, Block, IndexRequest, SlotRequest, SlotResponse, Transaction},
+    types::{Blob, Block, IndexRequest, ReorgBlockRequest, SlotRequest, SlotResponse, Transaction},
 };
 
 mod jwt_manager;
@@ -58,10 +58,18 @@ impl BlobscanClient {
         json_put!(&self.client, url, token, &req).map(|_: Option<()>| ())
     }
 
+    pub async fn handle_reorg(&self, slot: u32, depth: u32) -> ClientResult<()> {
+        let url = self.base_url.join("reorg-block")?;
+        let token = self.jwt_manager.get_token()?;
+        let req = ReorgBlockRequest { slot, depth };
+
+        json_put!(&self.client, url, token, &req).map(|_: Option<()>| ())
+    }
+
     pub async fn update_slot(&self, slot: u32) -> ClientResult<()> {
+        let url = self.base_url.join("slot")?;
         let token = self.jwt_manager.get_token()?;
         let req = SlotRequest { slot };
-        let url = self.base_url.join("slot")?;
 
         json_put!(&self.client, url, token, &req).map(|_: Option<()>| ())
     }

--- a/src/clients/blobscan/mod.rs
+++ b/src/clients/blobscan/mod.rs
@@ -6,7 +6,9 @@ use crate::{clients::common::ClientResult, json_get, json_put};
 
 use self::{
     jwt_manager::{Config as JWTManagerConfig, JWTManager},
-    types::{Blob, Block, IndexRequest, ReorgBlockRequest, SlotRequest, SlotResponse, Transaction},
+    types::{
+        Blob, Block, IndexRequest, ReorgedSlotRequest, SlotRequest, SlotResponse, Transaction,
+    },
 };
 
 mod jwt_manager;
@@ -59,9 +61,9 @@ impl BlobscanClient {
     }
 
     pub async fn handle_reorg(&self, slot: u32, depth: u32) -> ClientResult<()> {
-        let url = self.base_url.join("reorg-block")?;
+        let url = self.base_url.join("reorged-slot")?;
         let token = self.jwt_manager.get_token()?;
-        let req = ReorgBlockRequest { slot, depth };
+        let req = ReorgedSlotRequest { slot, depth };
 
         json_put!(&self.client, url, token, &req).map(|_: Option<()>| ())
     }

--- a/src/clients/blobscan/types.rs
+++ b/src/clients/blobscan/types.rs
@@ -68,7 +68,7 @@ pub struct IndexRequest {
 }
 
 #[derive(Serialize, Debug)]
-pub struct ReorgBlockRequest {
+pub struct ReorgedSlotRequest {
     pub slot: u32,
     pub depth: u32,
 }

--- a/src/clients/blobscan/types.rs
+++ b/src/clients/blobscan/types.rs
@@ -67,6 +67,12 @@ pub struct IndexRequest {
     pub blobs: Vec<Blob>,
 }
 
+#[derive(Serialize, Debug)]
+pub struct ReorgBlockRequest {
+    pub slot: u32,
+    pub depth: u32,
+}
+
 impl fmt::Debug for Blob {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -11,6 +11,7 @@ use tracing::{debug, error, info, warn, Instrument};
 
 use crate::{
     args::Args,
+    chain_reorg_handler::ChainReorgHandler,
     context::{Config as ContextConfig, Context},
     env::Environment,
     slots_processor::{Config as SlotsProcessorConfig, SlotsProcessor},
@@ -57,6 +58,10 @@ pub async fn run(env: Environment) -> Result<()> {
             return Err(error);
         }
     };
+
+    let chain_reorg_handler = ChainReorgHandler::new(context.clone());
+
+    let _handler = chain_reorg_handler.run();
 
     let beacon_client = context.beacon_client();
     let blobscan_client = context.blobscan_client();

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ use env::Environment;
 use utils::telemetry::{get_subscriber, init_subscriber};
 
 mod args;
+mod chain_reorg_handler;
 mod clients;
 mod context;
 mod env;

--- a/src/slots_processor/mod.rs
+++ b/src/slots_processor/mod.rs
@@ -10,7 +10,7 @@ use self::{
 use crate::context::Context;
 
 mod error;
-mod slot_processor;
+pub mod slot_processor;
 
 pub struct SlotsProcessor {
     context: Context,


### PR DESCRIPTION
Handle reorgs using Beacon API events: https://ethereum.github.io/beacon-APIs/#/Events/eventstream

Request URL: `{{<BEACON_CHAIN_URL}}/eth/v1/events?topics=chain_reorg`

 Example event from Goerli:
```
{
    event: chain_reorg
    data: {
        "slot": "7471713",
        "depth": "1",
        "old_head_block": "0x8da7b0042311f788d19703644d2b1ee498ce052f8ffaed5176d56525017ad38f",
        "old_head_state": "0xb9c0b3653d13ac01c4efdd8d000c5b19584a3b2073aa26e96e5e58b6068fc368",
        "new _head_block": "0xb9e7b5751e76ab804107468d7194315410cda7d6c500fe520bab610bbda44016",
        "new_head_state": "0x492c9056d0e72b464cd5e13ccd0ae3bf4b88c03b915356bee8f826f66f36b298",
        "epoch": "233491",
        "execution_optimistic": false
    }
}
