### PR TITLE
feat: index finalised checkpoint blocks

### DIFF
--- a/src/clients/beacon/mod.rs
+++ b/src/clients/beacon/mod.rs
@@ -78,7 +78,7 @@ impl BeaconClient {
             .iter()
             .map(|topic| topic.into())
             .collect::<Vec<String>>()
-            .join("&");
+            .join(",");
         let path = format!("v1/events?topics={topics}");
         let url = self.base_url.join(&path)?;
 

--- a/src/clients/beacon/mod.rs
+++ b/src/clients/beacon/mod.rs
@@ -38,6 +38,12 @@ impl BeaconClient {
     }
 
     pub async fn get_block(&self, block_id: &BlockId) -> ClientResult<Option<Block>> {
+        let block_id = match block_id {
+            BlockId::Hash(hash) => format!("0x{:x}", hash),
+            BlockId::Slot(slot) => slot.to_string(),
+            block_id => block_id.to_string(),
+        };
+
         let path = format!("v2/beacon/blocks/{block_id}");
         let url = self.base_url.join(path.as_str())?;
 

--- a/src/clients/beacon/types.rs
+++ b/src/clients/beacon/types.rs
@@ -10,6 +10,7 @@ pub enum BlockId {
     Head,
     Finalized,
     Slot(u32),
+    Hash(H256),
 }
 
 #[derive(Serialize, Debug)]
@@ -21,6 +22,8 @@ pub enum Topic {
 #[derive(Deserialize, Debug)]
 pub struct ExecutionPayload {
     pub block_hash: H256,
+    #[serde(deserialize_with = "deserialize_number")]
+    pub block_number: u32,
 }
 
 #[derive(Deserialize, Debug)]
@@ -30,7 +33,7 @@ pub struct BlockBody {
 }
 #[derive(Deserialize, Debug)]
 pub struct BlockMessage {
-    #[serde(deserialize_with = "deserialize_slot")]
+    #[serde(deserialize_with = "deserialize_number")]
     pub slot: u32,
     pub body: BlockBody,
     pub parent_root: H256,
@@ -76,18 +79,23 @@ pub struct InnerBlockHeader {
 #[derive(Deserialize, Debug)]
 pub struct BlockHeaderMessage {
     pub parent_root: H256,
-    #[serde(deserialize_with = "deserialize_slot")]
+    #[serde(deserialize_with = "deserialize_number")]
     pub slot: u32,
 }
 
 #[derive(Deserialize, Debug)]
 pub struct HeadBlockEventData {
-    #[serde(deserialize_with = "deserialize_slot")]
+    #[serde(deserialize_with = "deserialize_number")]
     pub slot: u32,
     pub block: H256,
 }
 
-fn deserialize_slot<'de, D>(deserializer: D) -> Result<u32, D::Error>
+#[derive(Deserialize, Debug)]
+pub struct FinalizedCheckpointEventData {
+    pub block: H256,
+}
+
+fn deserialize_number<'de, D>(deserializer: D) -> Result<u32, D::Error>
 where
     D: serde::Deserializer<'de>,
 {
@@ -102,6 +110,7 @@ impl fmt::Display for BlockId {
             BlockId::Head => write!(f, "head"),
             BlockId::Finalized => write!(f, "finalized"),
             BlockId::Slot(slot) => write!(f, "{}", slot),
+            BlockId::Hash(hash) => write!(f, "{}", hash),
         }
     }
 }

--- a/src/clients/beacon/types.rs
+++ b/src/clients/beacon/types.rs
@@ -99,9 +99,9 @@ fn deserialize_number<'de, D>(deserializer: D) -> Result<u32, D::Error>
 where
     D: serde::Deserializer<'de>,
 {
-    let slot = String::deserialize(deserializer)?;
+    let value = String::deserialize(deserializer)?;
 
-    slot.parse::<u32>().map_err(serde::de::Error::custom)
+    value.parse::<u32>().map_err(serde::de::Error::custom)
 }
 
 impl fmt::Display for BlockId {

--- a/src/clients/blobscan/types.rs
+++ b/src/clients/blobscan/types.rs
@@ -57,6 +57,8 @@ pub struct BlockchainSyncStateRequest {
     pub last_lower_synced_slot: Option<u32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub last_upper_synced_slot: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_finalized_block: Option<u32>,
 }
 
 #[derive(Deserialize, Debug)]
@@ -70,6 +72,7 @@ pub struct BlockchainSyncStateResponse {
 
 #[derive(Debug)]
 pub struct BlockchainSyncState {
+    pub last_finalized_block: Option<u32>,
     pub last_lower_synced_slot: Option<u32>,
     pub last_upper_synced_slot: Option<u32>,
 }
@@ -232,6 +235,7 @@ impl<'a> From<(&'a BeaconBlob, &'a H256, usize, &'a H256)> for Blob {
 impl From<BlockchainSyncStateResponse> for BlockchainSyncState {
     fn from(response: BlockchainSyncStateResponse) -> Self {
         Self {
+            last_finalized_block: None,
             last_lower_synced_slot: response.last_lower_synced_slot,
             last_upper_synced_slot: response.last_upper_synced_slot,
         }
@@ -243,6 +247,7 @@ impl From<BlockchainSyncState> for BlockchainSyncStateRequest {
         Self {
             last_lower_synced_slot: sync_state.last_lower_synced_slot,
             last_upper_synced_slot: sync_state.last_upper_synced_slot,
+            last_finalized_block: sync_state.last_finalized_block,
         }
     }
 }

--- a/src/indexer/error.rs
+++ b/src/indexer/error.rs
@@ -12,6 +12,8 @@ pub enum IndexerError {
     SynchronizerError(#[from] SynchronizerError),
     #[error("{0}")]
     SerdeError(#[from] serde_json::Error),
+    #[error("Unexpected event \"{event}\" received")]
+    UnexpectedEvent { event: String },
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/src/synchronizer/mod.rs
+++ b/src/synchronizer/mod.rs
@@ -217,6 +217,7 @@ impl Synchronizer {
                 .context
                 .blobscan_client()
                 .update_sync_state(BlockchainSyncState {
+                    last_finalized_block: None,
                     last_lower_synced_slot,
                     last_upper_synced_slot,
                 })


### PR DESCRIPTION
Related to the following [PR](https://github.com/Blobscan/blobscan/pull/252)

It updates the indexer to start indexing the last finalised checkpoint blocks as it's needed by the overall stats aggregation job  on the blobscan API.