### PR TITLE
feat: add disabling args

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -17,4 +17,8 @@ pub struct Args {
     /// Amount of slots to be processed before saving latest slot in the database
     #[arg(short, long)]
     pub slots_per_save: Option<u32>,
+
+    /// Disable slot checkpoint saving
+    #[arg(short, long)]
+    pub disable_checkpoints: Option<bool>,
 }

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,4 +1,4 @@
-use clap::Parser;
+use clap::{ArgAction, Parser};
 
 use crate::clients::beacon::types::BlockId;
 
@@ -18,11 +18,11 @@ pub struct Args {
     #[arg(short, long)]
     pub slots_per_save: Option<u32>,
 
-    /// Disable slot checkpoint saving
-    #[arg(short, long)]
-    pub disable_checkpoints: Option<bool>,
+    /// Disable slot checkpoint saving when syncing
+    #[arg(short = 'c', long, action = ArgAction::SetTrue)]
+    pub disable_sync_checkpoint_save: bool,
 
-    /// Disable histotircal synchronization
-    #[arg(short, long)]
-    pub disable_historical_sync: Option<bool>,
+    /// Disable historical synchronization
+    #[arg(short = 'd', long, action = ArgAction::SetTrue)]
+    pub disable_sync_historical: bool,
 }

--- a/src/args.rs
+++ b/src/args.rs
@@ -21,4 +21,8 @@ pub struct Args {
     /// Disable slot checkpoint saving
     #[arg(short, long)]
     pub disable_checkpoints: Option<bool>,
+
+    /// Disable histotircal synchronization
+    #[arg(short, long)]
+    pub disable_historical_sync: Option<bool>,
 }

--- a/src/indexer/mod.rs
+++ b/src/indexer/mod.rs
@@ -33,6 +33,7 @@ pub struct Indexer {
     dencun_fork_slot: u32,
     num_threads: u32,
     slots_checkpoint: Option<u32>,
+    disable_checkpoints: Option<bool>,
 }
 
 impl Indexer {
@@ -53,6 +54,8 @@ impl Indexer {
                 .map_err(|err| anyhow!("Failed to get number of available threads: {:?}", err))?
                 .get() as u32,
         };
+        let disable_checkpoints = args.disable_checkpoints;
+
         let dencun_fork_slot = env
             .dencun_fork_slot
             .unwrap_or(env.network_name.dencun_fork_slot());
@@ -62,6 +65,7 @@ impl Indexer {
             num_threads,
             slots_checkpoint,
             dencun_fork_slot,
+            disable_checkpoints,
         })
     }
 
@@ -314,6 +318,10 @@ impl Indexer {
 
     fn _create_synchronizer(&self) -> Synchronizer {
         let mut synchronizer_builder = SynchronizerBuilder::new();
+
+        if let Some(disable_checkpoints) = self.disable_checkpoints {
+            synchronizer_builder.with_disable_checkpoints(disable_checkpoints);
+        }
 
         synchronizer_builder.with_num_threads(self.num_threads);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -99,11 +99,9 @@ async fn run() -> AnyhowResult<()> {
     init_subscriber(subscriber);
 
     let args = Args::parse();
-    let run_opts = args
-        .disable_historical_sync
-        .map(|disable_historical_sync| RunOptions {
-            disable_historical_sync: Some(disable_historical_sync),
-        });
+    let run_opts = Some(RunOptions {
+        disable_sync_historical: args.disable_sync_historical,
+    });
 
     print_banner(&args, &env);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,6 +59,24 @@ pub fn print_banner(args: &Args, env: &Environment) {
         println!("Slots checkpoint size: 1000");
     }
 
+    println!(
+        "Disable sync checkpoint saving: {}",
+        if args.disable_sync_checkpoint_save {
+            "yes"
+        } else {
+            "no"
+        }
+    );
+
+    println!(
+        "Disable historical sync: {}",
+        if args.disable_sync_historical {
+            "yes"
+        } else {
+            "no"
+        }
+    );
+
     println!("Blobscan API endpoint: {}", env.blobscan_api_endpoint);
     println!(
         "CL endpoint: {:?}",

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@ use anyhow::{anyhow, Result as AnyhowResult};
 use args::Args;
 use clap::Parser;
 use env::Environment;
-use indexer::Indexer;
+use indexer::{Indexer, RunOptions};
 use url::Url;
 use utils::telemetry::{get_subscriber, init_subscriber};
 
@@ -99,11 +99,16 @@ async fn run() -> AnyhowResult<()> {
     init_subscriber(subscriber);
 
     let args = Args::parse();
+    let run_opts = args
+        .disable_historical_sync
+        .map(|disable_historical_sync| RunOptions {
+            disable_historical_sync: Some(disable_historical_sync),
+        });
 
     print_banner(&args, &env);
 
     Indexer::try_new(&env, &args)?
-        .run(args.from_slot)
+        .run(args.from_slot, run_opts)
         .await
         .map_err(|err| anyhow!(err))
 }

--- a/src/synchronizer/mod.rs
+++ b/src/synchronizer/mod.rs
@@ -18,7 +18,7 @@ pub struct SynchronizerBuilder {
     num_threads: u32,
     min_slots_per_thread: u32,
     slots_checkpoint: u32,
-    disable_checkpoints: bool,
+    disable_checkpoint_save: bool,
 }
 
 pub struct Synchronizer {
@@ -26,7 +26,7 @@ pub struct Synchronizer {
     num_threads: u32,
     min_slots_per_thread: u32,
     slots_checkpoint: u32,
-    disable_checkpoints: bool,
+    disable_checkpoint_save: bool,
 }
 
 impl Default for SynchronizerBuilder {
@@ -35,7 +35,7 @@ impl Default for SynchronizerBuilder {
             num_threads: 1,
             min_slots_per_thread: 50,
             slots_checkpoint: 1000,
-            disable_checkpoints: false,
+            disable_checkpoint_save: false,
         }
     }
 }
@@ -45,8 +45,8 @@ impl SynchronizerBuilder {
         SynchronizerBuilder::default()
     }
 
-    pub fn with_disable_checkpoints(&mut self, disable_checkpoints: bool) -> &mut Self {
-        self.disable_checkpoints = disable_checkpoints;
+    pub fn with_disable_checkpoint_save(&mut self, disable_checkpoint_save: bool) -> &mut Self {
+        self.disable_checkpoint_save = disable_checkpoint_save;
 
         self
     }
@@ -68,7 +68,7 @@ impl SynchronizerBuilder {
             num_threads: self.num_threads,
             min_slots_per_thread: self.min_slots_per_thread,
             slots_checkpoint: self.slots_checkpoint,
-            disable_checkpoints: self.disable_checkpoints,
+            disable_checkpoint_save: self.disable_checkpoint_save,
         }
     }
 }
@@ -83,12 +83,8 @@ impl Synchronizer {
         let mut final_slot = self._resolve_to_slot(final_block_id).await?;
 
         loop {
-            if self.disable_checkpoints {
-                self._sync_slots(initial_slot, final_slot).await?;
-            } else {
-                self._sync_slots_by_checkpoints(initial_slot, final_slot)
-                    .await?;
-            }
+            self._sync_slots_by_checkpoints(initial_slot, final_slot)
+                .await?;
 
             let latest_final_slot = self._resolve_to_slot(final_block_id).await?;
 
@@ -220,41 +216,43 @@ impl Synchronizer {
             let last_lower_synced_slot = if is_reverse_sync { last_slot } else { None };
             let last_upper_synced_slot = if is_reverse_sync { None } else { last_slot };
 
-            if let Err(error) = self
-                .context
-                .blobscan_client()
-                .update_sync_state(BlockchainSyncState {
-                    last_finalized_block: None,
-                    last_lower_synced_slot,
-                    last_upper_synced_slot,
-                })
-                .await
-            {
-                let new_synced_slot = match last_lower_synced_slot {
-                    Some(slot) => slot,
-                    None => match last_upper_synced_slot {
+            if !self.disable_checkpoint_save {
+                if let Err(error) = self
+                    .context
+                    .blobscan_client()
+                    .update_sync_state(BlockchainSyncState {
+                        last_finalized_block: None,
+                        last_lower_synced_slot,
+                        last_upper_synced_slot,
+                    })
+                    .await
+                {
+                    let new_synced_slot = match last_lower_synced_slot {
                         Some(slot) => slot,
-                        None => {
-                            return Err(SynchronizerError::Other(anyhow!(
-                                "Failed to get new last synced slot: last_lower_synced_slot and last_upper_synced_slot are both None"
-                            )))
-                        }
-                    },
-                };
+                        None => match last_upper_synced_slot {
+                            Some(slot) => slot,
+                            None => {
+                                return Err(SynchronizerError::Other(anyhow!(
+                                    "Failed to get new last synced slot: last_lower_synced_slot and last_upper_synced_slot are both None"
+                                )))
+                            }
+                        },
+                    };
 
-                return Err(SynchronizerError::FailedSlotCheckpointSave {
-                    slot: new_synced_slot,
-                    error,
-                });
-            }
+                    return Err(SynchronizerError::FailedSlotCheckpointSave {
+                        slot: new_synced_slot,
+                        error,
+                    });
+                }
 
-            if unprocessed_slots >= self.slots_checkpoint {
-                debug!(
-                    target = "synchronizer",
-                    new_last_lower_synced_slot = last_lower_synced_slot,
-                    new_last_upper_synced_slot = last_upper_synced_slot,
-                    "Checkpoint reached. Last synced slot saved…"
-                );
+                if unprocessed_slots >= self.slots_checkpoint {
+                    debug!(
+                        target = "synchronizer",
+                        new_last_lower_synced_slot = last_lower_synced_slot,
+                        new_last_upper_synced_slot = last_upper_synced_slot,
+                        "Checkpoint reached. Last synced slot saved…"
+                    );
+                }
             }
 
             current_slot = if is_reverse_sync {


### PR DESCRIPTION
It introduces support for disabling both the indexer's historical synchronization and the synchronizer's slot checkpoint save via flags.

These flags are intended to be used for re-indexing past slots that may not have been indexed correctly without modifying the current blockchain sync state, providing more flexibility to the indexer itself.

```
  -c, --disable-sync-checkpoint-save
          Disable slot checkpoint saving when syncing
  -d, --disable-sync-historical
          Disable historical synchronization
```