### PR TITLE
test: refactor to enable component mocking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,9 +127,9 @@ checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
 name = "async-trait"
-version = "0.1.77"
+version = "0.1.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
+checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -319,6 +319,7 @@ dependencies = [
  "chrono",
  "clap",
  "dotenv",
+ "dyn-clone",
  "envy",
  "ethers",
  "futures",
@@ -726,6 +727,12 @@ name = "dunce"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b"
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
 
 [[package]]
 name = "ecdsa"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -325,6 +325,7 @@ dependencies = [
  "futures",
  "hex",
  "jsonwebtoken",
+ "mockall",
  "reqwest",
  "reqwest-eventsource",
  "sentry",
@@ -721,6 +722,12 @@ name = "dotenv"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
+
+[[package]]
+name = "downcast"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
 
 [[package]]
 name = "dunce"
@@ -1185,6 +1192,12 @@ checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fragile"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 
 [[package]]
 name = "funty"
@@ -1765,6 +1778,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "mockall"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43766c2b5203b10de348ffe19f7e54564b64f3d6018ff7648d1e2d6d3a0f0a48"
+dependencies = [
+ "cfg-if",
+ "downcast",
+ "fragile",
+ "lazy_static",
+ "mockall_derive",
+ "predicates",
+ "predicates-tree",
+]
+
+[[package]]
+name = "mockall_derive"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af7cbce79ec385a1d4f54baa90a76401eb15d9cab93685f62e7e9f942aa00ae2"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.52",
+]
+
+[[package]]
 name = "native-tls"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2135,6 +2175,32 @@ name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
+name = "predicates"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68b87bfd4605926cdfefc1c3b5f8fe560e3feca9d5552cf68c466d3d8236c7e8"
+dependencies = [
+ "anstyle",
+ "predicates-core",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b794032607612e7abeb4db69adb4e33590fa6cf1149e95fd7cb00e634b92f174"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368ba315fb8c5052ab692e68a0eefec6ec57b23a36959c14496f0b0df2c0cecf"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
 
 [[package]]
 name = "primitive-types"
@@ -3044,6 +3110,12 @@ dependencies = [
  "rustix",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "termtree"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "thiserror"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,3 +35,6 @@ anyhow = { version = "1.0.70", features = ["backtrace"] }
 thiserror = "1.0.40"
 sentry = { version = "0.31.2", features = ["debug-images"] }
 sentry-tracing = "0.31.2"
+
+[dev-dependencies]
+mockall = "0.12.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-async-trait = "0.1.66"
+async-trait = "0.1.80"
+dyn-clone = "1.0.17"
 dotenv = "0.15.0"
 envy = "0.4.2"
 ethers = "1.0.2"

--- a/src/clients/beacon/mod.rs
+++ b/src/clients/beacon/mod.rs
@@ -7,6 +7,9 @@ use backoff::ExponentialBackoff;
 use reqwest::{Client, Url};
 use reqwest_eventsource::EventSource;
 
+#[cfg(test)]
+use mockall::automock;
+
 use crate::{
     clients::{beacon::types::BlockHeaderResponse, common::ClientResult},
     json_get,
@@ -29,6 +32,7 @@ pub struct Config {
 }
 
 #[async_trait]
+#[cfg_attr(test, automock)]
 pub trait CommonBeaconClient: Send + Sync + Debug {
     async fn get_block(&self, block_id: &BlockId) -> ClientResult<Option<Block>>;
     async fn get_block_header(&self, block_id: &BlockId) -> ClientResult<Option<BlockHeader>>;

--- a/src/clients/beacon/mod.rs
+++ b/src/clients/beacon/mod.rs
@@ -1,5 +1,9 @@
+use std::fmt::Debug;
+
 use anyhow::Context as AnyhowContext;
+use async_trait::async_trait;
 use backoff::ExponentialBackoff;
+
 use reqwest::{Client, Url};
 use reqwest_eventsource::EventSource;
 
@@ -24,6 +28,14 @@ pub struct Config {
     pub exp_backoff: Option<ExponentialBackoff>,
 }
 
+#[async_trait]
+pub trait CommonBeaconClient: Send + Sync + Debug {
+    async fn get_block(&self, block_id: &BlockId) -> ClientResult<Option<Block>>;
+    async fn get_block_header(&self, block_id: &BlockId) -> ClientResult<Option<BlockHeader>>;
+    async fn get_blobs(&self, block_id: &BlockId) -> ClientResult<Option<Vec<Blob>>>;
+    fn subscribe_to_events(&self, topics: &[Topic]) -> ClientResult<EventSource>;
+}
+
 impl BeaconClient {
     pub fn try_with_client(client: Client, config: Config) -> ClientResult<Self> {
         let base_url = Url::parse(&format!("{}/eth/", config.base_url))
@@ -36,8 +48,11 @@ impl BeaconClient {
             exp_backoff,
         })
     }
+}
 
-    pub async fn get_block(&self, block_id: &BlockId) -> ClientResult<Option<Block>> {
+#[async_trait]
+impl CommonBeaconClient for BeaconClient {
+    async fn get_block(&self, block_id: &BlockId) -> ClientResult<Option<Block>> {
         let path = format!("v2/beacon/blocks/{}", { block_id.to_detailed_string() });
         let url = self.base_url.join(path.as_str())?;
 
@@ -47,7 +62,7 @@ impl BeaconClient {
         })
     }
 
-    pub async fn get_block_header(&self, block_id: &BlockId) -> ClientResult<Option<BlockHeader>> {
+    async fn get_block_header(&self, block_id: &BlockId) -> ClientResult<Option<BlockHeader>> {
         let path = format!("v1/beacon/headers/{}", { block_id.to_detailed_string() });
         let url = self.base_url.join(path.as_str())?;
 
@@ -63,7 +78,7 @@ impl BeaconClient {
         })
     }
 
-    pub async fn get_blobs(&self, block_id: &BlockId) -> ClientResult<Option<Vec<Blob>>> {
+    async fn get_blobs(&self, block_id: &BlockId) -> ClientResult<Option<Vec<Blob>>> {
         let path = format!("v1/beacon/blob_sidecars/{}", {
             block_id.to_detailed_string()
         });
@@ -75,7 +90,7 @@ impl BeaconClient {
         })
     }
 
-    pub fn subscribe_to_events(&self, topics: &[Topic]) -> ClientResult<EventSource> {
+    fn subscribe_to_events(&self, topics: &[Topic]) -> ClientResult<EventSource> {
         let topics = topics
             .iter()
             .map(|topic| topic.into())

--- a/src/clients/blobscan/mod.rs
+++ b/src/clients/blobscan/mod.rs
@@ -5,6 +5,9 @@ use backoff::ExponentialBackoff;
 use chrono::TimeDelta;
 use reqwest::{Client, Url};
 
+#[cfg(test)]
+use mockall::automock;
+
 use crate::{
     clients::{blobscan::types::ReorgedSlotsResponse, common::ClientResult},
     json_get, json_put,
@@ -23,6 +26,7 @@ mod jwt_manager;
 pub mod types;
 
 #[async_trait]
+#[cfg_attr(test, automock)]
 pub trait CommonBlobscanClient: Send + Sync + Debug {
     fn try_with_client(client: Client, config: Config) -> ClientResult<Self>
     where
@@ -53,6 +57,7 @@ pub struct Config {
 }
 
 #[async_trait]
+
 impl CommonBlobscanClient for BlobscanClient {
     fn try_with_client(client: Client, config: Config) -> ClientResult<Self> {
         let base_url = Url::parse(&format!("{}/", config.base_url))?;

--- a/src/indexer/event_handlers/finalized_checkpoint.rs
+++ b/src/indexer/event_handlers/finalized_checkpoint.rs
@@ -1,3 +1,4 @@
+use ethers::providers::Http as HttpProvider;
 use tracing::info;
 
 use crate::{
@@ -6,7 +7,7 @@ use crate::{
         blobscan::types::BlockchainSyncState,
         common::ClientError,
     },
-    context::Context,
+    context::CommonContext,
     utils::web3::get_full_hash,
 };
 
@@ -22,12 +23,12 @@ pub enum FinalizedCheckpointEventHandlerError {
     BlobscanFinalizedBlockUpdateFailure(#[source] ClientError),
 }
 
-pub struct FinalizedCheckpointHandler {
-    context: Context,
+pub struct FinalizedCheckpointHandler<T> {
+    context: Box<dyn CommonContext<T>>,
 }
 
-impl FinalizedCheckpointHandler {
-    pub fn new(context: Context) -> Self {
+impl FinalizedCheckpointHandler<HttpProvider> {
+    pub fn new(context: Box<dyn CommonContext<HttpProvider>>) -> Self {
         FinalizedCheckpointHandler { context }
     }
 

--- a/src/indexer/event_handlers/head.rs
+++ b/src/indexer/event_handlers/head.rs
@@ -1,6 +1,6 @@
 use std::cmp;
 
-use ethers::types::H256;
+use ethers::{providers::Http as HttpProvider, types::H256};
 use tracing::info;
 
 use crate::{
@@ -9,7 +9,7 @@ use crate::{
         blobscan::types::BlockchainSyncState,
         common::ClientError,
     },
-    context::Context,
+    context::CommonContext,
     synchronizer::{error::SynchronizerError, Synchronizer},
 };
 
@@ -29,15 +29,19 @@ pub enum HeadEventHandlerError {
     BlobscanSyncStateUpdateError(#[source] ClientError),
 }
 
-pub struct HeadEventHandler {
-    context: Context,
-    synchronizer: Synchronizer,
+pub struct HeadEventHandler<T> {
+    context: Box<dyn CommonContext<T>>,
+    synchronizer: Synchronizer<T>,
     start_block_id: BlockId,
     last_block_hash: Option<H256>,
 }
 
-impl HeadEventHandler {
-    pub fn new(context: Context, synchronizer: Synchronizer, start_block_id: BlockId) -> Self {
+impl HeadEventHandler<HttpProvider> {
+    pub fn new(
+        context: Box<dyn CommonContext<HttpProvider>>,
+        synchronizer: Synchronizer<HttpProvider>,
+        start_block_id: BlockId,
+    ) -> Self {
         HeadEventHandler {
             context,
             synchronizer,

--- a/src/indexer/event_handlers/head.rs
+++ b/src/indexer/event_handlers/head.rs
@@ -10,7 +10,7 @@ use crate::{
         common::ClientError,
     },
     context::CommonContext,
-    synchronizer::{error::SynchronizerError, Synchronizer},
+    synchronizer::{error::SynchronizerError, CommonSynchronizer},
 };
 
 #[derive(Debug, thiserror::Error)]
@@ -31,7 +31,7 @@ pub enum HeadEventHandlerError {
 
 pub struct HeadEventHandler<T> {
     context: Box<dyn CommonContext<T>>,
-    synchronizer: Synchronizer<T>,
+    synchronizer: Box<dyn CommonSynchronizer>,
     start_block_id: BlockId,
     last_block_hash: Option<H256>,
 }
@@ -39,7 +39,7 @@ pub struct HeadEventHandler<T> {
 impl HeadEventHandler<HttpProvider> {
     pub fn new(
         context: Box<dyn CommonContext<HttpProvider>>,
-        synchronizer: Synchronizer<HttpProvider>,
+        synchronizer: Box<dyn CommonSynchronizer>,
         start_block_id: BlockId,
     ) -> Self {
         HeadEventHandler {

--- a/src/indexer/mod.rs
+++ b/src/indexer/mod.rs
@@ -14,7 +14,7 @@ use crate::{
     context::{CommonContext, Config as ContextConfig, Context},
     env::Environment,
     indexer::error::HistoricalIndexingError,
-    synchronizer::{CheckpointType, Synchronizer, SynchronizerBuilder},
+    synchronizer::{CheckpointType, CommonSynchronizer, SynchronizerBuilder},
 };
 
 use self::{
@@ -289,7 +289,7 @@ impl Indexer<HttpProvider> {
         })
     }
 
-    fn create_synchronizer(&self, checkpoint_type: CheckpointType) -> Synchronizer<HttpProvider> {
+    fn create_synchronizer(&self, checkpoint_type: CheckpointType) -> Box<dyn CommonSynchronizer> {
         let mut synchronizer_builder = SynchronizerBuilder::new();
 
         if let Some(checkpoint_slots) = self.checkpoint_slots {
@@ -302,6 +302,6 @@ impl Indexer<HttpProvider> {
 
         synchronizer_builder.with_num_threads(self.num_threads);
 
-        synchronizer_builder.build(self.context.clone())
+        Box::new(synchronizer_builder.build(self.context.clone()))
     }
 }

--- a/src/slots_processor/mod.rs
+++ b/src/slots_processor/mod.rs
@@ -1,6 +1,9 @@
 use anyhow::{anyhow, Context as AnyhowContext, Result};
 
-use ethers::prelude::*;
+use ethers::{
+    providers::{Http as HttpProvider, Middleware},
+    types::H256,
+};
 use tracing::{debug, info};
 
 use crate::{
@@ -8,7 +11,7 @@ use crate::{
         beacon::types::{BlockHeader, BlockId},
         blobscan::types::{Blob, Block, Transaction},
     },
-    context::Context,
+    context::CommonContext,
 };
 
 use self::error::{SlotProcessingError, SlotsProcessorError};
@@ -17,8 +20,8 @@ use self::helpers::{create_tx_hash_versioned_hashes_mapping, create_versioned_ha
 pub mod error;
 mod helpers;
 
-pub struct SlotsProcessor {
-    context: Context,
+pub struct SlotsProcessor<T> {
+    context: Box<dyn CommonContext<T>>,
 }
 
 #[derive(Debug, Clone)]
@@ -36,8 +39,8 @@ impl From<BlockHeader> for BlockData {
     }
 }
 
-impl SlotsProcessor {
-    pub fn new(context: Context) -> SlotsProcessor {
+impl SlotsProcessor<HttpProvider> {
+    pub fn new(context: Box<dyn CommonContext<HttpProvider>>) -> SlotsProcessor<HttpProvider> {
         Self { context }
     }
 

--- a/src/synchronizer/mod.rs
+++ b/src/synchronizer/mod.rs
@@ -7,6 +7,9 @@ use futures::future::join_all;
 use tokio::task::JoinHandle;
 use tracing::{debug, info, Instrument};
 
+#[cfg(test)]
+use mockall::automock;
+
 use crate::{
     clients::{beacon::types::BlockId, blobscan::types::BlockchainSyncState, common::ClientError},
     context::CommonContext,
@@ -18,6 +21,7 @@ use self::error::{SlotsChunksErrors, SynchronizerError};
 pub mod error;
 
 #[async_trait]
+#[cfg_attr(test, automock)]
 pub trait CommonSynchronizer: Send + Sync + Debug {
     async fn run(
         &self,


### PR DESCRIPTION
This PR introduces a refactoring to allow mocking of every main indexer component, enabling us to test each one separately through unit tests. It also creates the necessary mocks.

It achieves this by abstracting each component dependency into a trait, which our mocks can implement later.