### PR TITLE
fix: resolve JWT expiration token validation

### DIFF
--- a/src/clients/blobscan/jwt_manager.rs
+++ b/src/clients/blobscan/jwt_manager.rs
@@ -47,12 +47,12 @@ impl JWTManager {
 
         match *token_guard {
             Some(ref token) => {
-                let now = Utc::now() - self.safety_margin;
+                let now = Utc::now() + self.safety_margin;
                 let expiration_date = expr_guard.ok_or(anyhow::anyhow!(
                     "JWT expiration date not set. This should not happen"
                 ))?;
 
-                if now > expiration_date {
+                if now >= expiration_date {
                     debug!(
                         expiration_date = expiration_date.to_string(),
                         "JWT expired. Refreshing token"


### PR DESCRIPTION
It improves token expiration validation by ensuring the expiration time is correctly compared against the current time plus the safety margin, addressing the previous issue where the margin was mistakenly subtracted.