### PR TITLE
feat: use last synced block slot and root

### DIFF
--- a/src/clients/blobscan/types.rs
+++ b/src/clients/blobscan/types.rs
@@ -68,6 +68,10 @@ pub struct BlockchainSyncStateRequest {
     pub last_upper_synced_slot: Option<u32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub last_finalized_block: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_upper_synced_block_root: Option<B256>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_upper_synced_block_slot: Option<u32>,
 }
 
 #[derive(Deserialize, Debug)]
@@ -77,6 +81,10 @@ pub struct BlockchainSyncStateResponse {
     pub last_lower_synced_slot: Option<u32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub last_upper_synced_slot: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_upper_synced_block_root: Option<B256>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_upper_synced_block_slot: Option<u32>,
 }
 
 #[derive(Debug, PartialEq)]
@@ -84,6 +92,8 @@ pub struct BlockchainSyncState {
     pub last_finalized_block: Option<u32>,
     pub last_lower_synced_slot: Option<u32>,
     pub last_upper_synced_slot: Option<u32>,
+    pub last_upper_synced_block_root: Option<B256>,
+    pub last_upper_synced_block_slot: Option<u32>,
 }
 
 #[derive(Serialize, Debug)]
@@ -253,6 +263,8 @@ impl From<BlockchainSyncStateResponse> for BlockchainSyncState {
             last_finalized_block: None,
             last_lower_synced_slot: response.last_lower_synced_slot,
             last_upper_synced_slot: response.last_upper_synced_slot,
+            last_upper_synced_block_root: response.last_upper_synced_block_root,
+            last_upper_synced_block_slot: response.last_upper_synced_block_slot,
         }
     }
 }
@@ -263,6 +275,8 @@ impl From<BlockchainSyncState> for BlockchainSyncStateRequest {
             last_lower_synced_slot: sync_state.last_lower_synced_slot,
             last_upper_synced_slot: sync_state.last_upper_synced_slot,
             last_finalized_block: sync_state.last_finalized_block,
+            last_upper_synced_block_root: sync_state.last_upper_synced_block_root,
+            last_upper_synced_block_slot: sync_state.last_upper_synced_block_slot,
         }
     }
 }

--- a/src/indexer/event_handlers/finalized_checkpoint.rs
+++ b/src/indexer/event_handlers/finalized_checkpoint.rs
@@ -71,9 +71,11 @@ where
         self.context
             .blobscan_client()
             .update_sync_state(BlockchainSyncState {
+                last_finalized_block: Some(last_finalized_block_number),
                 last_lower_synced_slot: None,
                 last_upper_synced_slot: None,
-                last_finalized_block: Some(last_finalized_block_number),
+                last_upper_synced_block_root: None,
+                last_upper_synced_block_slot: None,
             })
             .await
             .map_err(FinalizedCheckpointEventHandlerError::BlobscanFinalizedBlockUpdateFailure)?;

--- a/src/indexer/mod.rs
+++ b/src/indexer/mod.rs
@@ -112,13 +112,17 @@ impl Indexer<ReqwestTransport> {
         };
 
         let last_synced_block = sync_state.and_then(|state| {
-            state
-                .last_upper_synced_slot
-                .map(|last_upper_synced_slot| BlockHeader {
-                    slot: last_upper_synced_slot,
-                    root: B256::ZERO,
+            match (
+                state.last_upper_synced_block_root,
+                state.last_upper_synced_slot,
+            ) {
+                (Some(root), Some(slot)) => Some(BlockHeader {
                     parent_root: B256::ZERO,
-                })
+                    root,
+                    slot,
+                }),
+                _ => None,
+            }
         });
 
         let upper_indexed_block_id = match &last_synced_block {

--- a/src/indexer/mod.rs
+++ b/src/indexer/mod.rs
@@ -111,7 +111,7 @@ impl Indexer<ReqwestTransport> {
             },
         };
 
-        let last_synced_block = sync_state.and_then(|state| {
+        let last_synced_block = sync_state.as_ref().and_then(|state| {
             match (
                 state.last_upper_synced_block_root,
                 state.last_upper_synced_slot,
@@ -125,14 +125,10 @@ impl Indexer<ReqwestTransport> {
             }
         });
 
-        let upper_indexed_block_id = match &last_synced_block {
-            Some(block) => block.slot.into(),
-            None => BlockId::Head,
-        };
-
         info!(
-            lower_indexed_block_id = current_lower_block_id.to_string(),
-            upper_indexed_block_id = upper_indexed_block_id.to_string(),
+            last_lowest_synced_slot = ?current_lower_block_id,
+            last_upper_synced_block_slot = ?last_synced_block.as_ref().map(|block| block.slot),
+            last_upper_synced_block_root = ?last_synced_block.as_ref().map(|block| block.root),
             "Starting indexer…",
         );
 

--- a/src/synchronizer/mod.rs
+++ b/src/synchronizer/mod.rs
@@ -262,16 +262,20 @@ impl Synchronizer<ReqwestTransport> {
             });
 
             if self.checkpoint_type != CheckpointType::Disabled {
-                let last_lower_synced_slot = if self.checkpoint_type == CheckpointType::Lower {
-                    last_slot
-                } else {
-                    None
-                };
-                let last_upper_synced_slot = if self.checkpoint_type == CheckpointType::Upper {
-                    last_slot
-                } else {
-                    None
-                };
+                let mut last_lower_synced_slot = None;
+                let mut last_upper_synced_slot = None;
+                let mut last_upper_synced_block_root = None;
+                let mut last_upper_synced_block_slot = None;
+
+                if self.checkpoint_type == CheckpointType::Lower {
+                    last_lower_synced_slot = last_slot;
+                } else if self.checkpoint_type == CheckpointType::Upper {
+                    last_upper_synced_slot = last_slot;
+                    last_upper_synced_block_root =
+                        self.last_synced_block.as_ref().map(|block| block.root);
+                    last_upper_synced_block_slot =
+                        self.last_synced_block.as_ref().map(|block| block.slot);
+                }
 
                 if let Err(error) = self
                     .context
@@ -280,6 +284,8 @@ impl Synchronizer<ReqwestTransport> {
                         last_finalized_block: None,
                         last_lower_synced_slot,
                         last_upper_synced_slot,
+                        last_upper_synced_block_root,
+                        last_upper_synced_block_slot,
                     })
                     .await
                 {


### PR DESCRIPTION
This PR enhances the indexer’s handling of reorg scenarios when resuming from the last indexed slot, which may have been affected by a reorganization.

By keeping track of the last synced block root, the indexer can compare it with the parent of the current block to detect a reorg