### PR TITLE
feat: add timeouts to prevent indexer hang during sync operations

### DIFF
--- a/src/slots_processor/error.rs
+++ b/src/slots_processor/error.rs
@@ -8,6 +8,11 @@ pub enum SlotProcessingError {
     ClientError(#[from] crate::clients::common::ClientError),
     #[error(transparent)]
     Provider(#[from] alloy::transports::TransportError),
+    #[error("Operation timed out: {operation} for slot {slot}")]
+    OperationTimeout {
+        operation: String,
+        slot: u32,
+    },
     #[error(transparent)]
     Other(#[from] anyhow::Error),
 }

--- a/src/synchronizer/error.rs
+++ b/src/synchronizer/error.rs
@@ -19,6 +19,11 @@ pub enum SynchronizerError {
         slot: u32,
         error: crate::clients::common::ClientError,
     },
+    #[error("Operation timed out: {operation} for block_id {block_id}")]
+    OperationTimeout {
+        operation: String,
+        block_id: String,
+    },
     #[error(transparent)]
     Other(#[from] anyhow::Error),
 }


### PR DESCRIPTION
This commit implements timeout mechanisms throughout the synchronizer and slots_processor modules to prevent indefinite hangs. Key changes include:

- Add configurable request_timeout parameter to Synchronizer and SlotsProcessor
- Implement timeouts for network operations with proper error handling
- Add longer timeouts for more complex operations like block processing
- Create appropriate error types (OperationTimeout) with detailed error messages

These changes ensure operations fail gracefully with clear error messages after timeout periods instead of hanging indefinitely, allowing the service to recover through pod restarts when network or processing issues occur.