### PR TITLE
feat: add retry logic to API PUT requests using exponential backoff

### DIFF
--- a/src/clients/blobscan/mod.rs
+++ b/src/clients/blobscan/mod.rs
@@ -51,13 +51,13 @@ pub struct BlobscanClient {
     base_url: Url,
     client: reqwest::Client,
     jwt_manager: JWTManager,
-    exp_backoff: Option<ExponentialBackoff>,
+    exp_backoff: ExponentialBackoff,
 }
 
 pub struct Config {
     pub base_url: String,
     pub secret_key: String,
-    pub exp_backoff: Option<ExponentialBackoff>,
+    pub exp_backoff: ExponentialBackoff,
 }
 
 #[async_trait]
@@ -94,7 +94,7 @@ impl CommonBlobscanClient for BlobscanClient {
             blobs,
         };
 
-        json_put!(&self.client, url, token, &req).map(|_: Option<()>| ())
+        json_put!(&self.client, url, token, &req, self.exp_backoff.clone()).map(|_: Option<()>| ())
     }
 
     async fn get_block(&self, slot: u32) -> ClientResult<Option<BlobscanBlock>> {
@@ -116,7 +116,7 @@ impl CommonBlobscanClient for BlobscanClient {
             rewinded_blocks,
         };
 
-        json_put!(&self.client, url, ReorgedBlocksRequestBody, token, &req).map(|_| ())
+        json_put!(&self.client, url, ReorgedBlocksRequestBody, token, &req, self.exp_backoff.clone()).map(|_| ())
     }
 
     async fn update_sync_state(&self, sync_state: BlockchainSyncState) -> ClientResult<()> {
@@ -124,7 +124,7 @@ impl CommonBlobscanClient for BlobscanClient {
         let token = self.jwt_manager.get_token()?;
         let req: BlockchainSyncStateRequest = sync_state.into();
 
-        json_put!(&self.client, url, token, &req).map(|_: Option<()>| ())
+        json_put!(&self.client, url, token, &req, self.exp_backoff.clone()).map(|_: Option<()>| ())
     }
 
     async fn get_sync_state(&self) -> ClientResult<Option<BlockchainSyncState>> {


### PR DESCRIPTION
- **Prevents crashes on API timeouts by retrying requests automatically**
- Implements retry functionality in the json_put! macro similar to json_get!
- Changes ExponentialBackoff from optional to mandatory in BlobscanClient
- Simplifies macro implementations by removing conditional paths

Example of crash:

```
│ 2025-05-16T10:57:57.692442Z  INFO blob_indexer::indexer: Starting indexer… last_lowest_synced_slot=Slot(8626175) last_upper_synced_block_slot=Some(11698177) last_upper_synced_block_root=Som │
│ 2025-05-16T10:57:57.756092Z  INFO indexer:live: blob_indexer::indexer: Subscribed to beacon SSE stream: head, finalized_checkpoint                                                            │
│ 2025-05-16T10:58:01.014070Z  INFO indexer:live:head_block: blob_indexer::synchronizer: Syncing 15910 slots… initial_slot=11698178 final_slot=11714088                                         │
│ 2025-05-16T10:58:01.787836Z  WARN indexer:live:head_block: blob_indexer::clients::blobscan: Unexpected response from server method="PUT" url=http://blobscan-api:3001/indexer/block-txs-blobs │
│ 2025-05-16T10:58:01.788397Z ERROR blob_indexer::indexer: An error occurred while running a syncing task error=LiveIndexingError(BeaconEventHandlingError(HeadEventHandlerError(BlockSyncedErr │
│ Error: failed to handle beacon event                                                                                                                                                          │
│                                                                                                                                                                                               │
│ Caused by:                                                                                                                                                                                    │
│     0: failed to index head block                                                                                                                                                             │
│     1: Failed to parallel process slots from 11698178 to 11699178:                                                                                                                            │
│        - Error processing slots range 11698178-11699178. Slot 11698179 failed: API usage error: Code: INTERNAL_SERVER_ERROR, Message: "Blob propagator failed: Failed to propagate blobs with │
│                                                                                                                                                                                               │
│ stream closed EOF for staging/blobscan-indexer-86d7d949d4-vqzgw (blobscan-indexer)                                                                                                            │
```