### PR TITLE
feat: send epoch to the index endpoint

### DIFF
--- a/src/clients/beacon/types.rs
+++ b/src/clients/beacon/types.rs
@@ -45,6 +45,8 @@ pub struct SpecResponse {
 pub struct Spec {
     #[serde(rename = "DEPOSIT_NETWORK_ID", deserialize_with = "deserialize_u64")]
     pub deposit_network_id: u64,
+    #[serde(rename = "SLOTS_PER_EPOCH", deserialize_with = "deserialize_u64")]
+    pub slots_per_epoch: u64,
 }
 #[derive(Deserialize, Debug)]
 pub struct Block {

--- a/src/clients/blobscan/types.rs
+++ b/src/clients/blobscan/types.rs
@@ -24,6 +24,7 @@ pub struct Block {
     pub hash: B256,
     pub timestamp: BlockTimestamp,
     pub slot: u32,
+    pub epoch: u32,
     pub blob_gas_used: U256,
     pub excess_blob_gas: U256,
 }
@@ -113,11 +114,15 @@ impl fmt::Debug for Blob {
     }
 }
 
-impl<'a> TryFrom<(&'a ExecutionBlock<ExecutionTransaction>, u32)> for Block {
+impl<'a> TryFrom<(&'a ExecutionBlock<ExecutionTransaction>, u32, u32)> for Block {
     type Error = anyhow::Error;
 
     fn try_from(
-        (execution_block, slot): (&'a ExecutionBlock<ExecutionTransaction>, u32),
+        (execution_block, slot, slots_per_epoch): (
+            &'a ExecutionBlock<ExecutionTransaction>,
+            u32,
+            u32,
+        ),
     ) -> Result<Self, Self::Error> {
         let number = execution_block.header.number;
         let hash = execution_block.header.hash;
@@ -143,11 +148,14 @@ impl<'a> TryFrom<(&'a ExecutionBlock<ExecutionTransaction>, u32)> for Block {
             }
         };
 
+        let epoch = slot / slots_per_epoch;
+
         Ok(Self {
             number,
             hash,
             timestamp,
             slot,
+            epoch,
             blob_gas_used,
             excess_blob_gas,
         })

--- a/src/context.rs
+++ b/src/context.rs
@@ -31,6 +31,8 @@ pub trait CommonContext: Send + Sync + DynClone {
     fn network(&self) -> &Network;
     fn provider(&self) -> &dyn Provider<Ethereum>;
     fn syncing_settings(&self) -> &SyncingSettings;
+    /// Number of slots per epoch, as reported by the consensus client's spec.
+    fn slots_per_epoch(&self) -> u32;
 }
 
 dyn_clone::clone_trait_object!(CommonContext);
@@ -38,6 +40,7 @@ dyn_clone::clone_trait_object!(CommonContext);
 
 struct ContextRef {
     pub network: Network,
+    pub slots_per_epoch: u32,
     pub beacon_client: Box<dyn CommonBeaconClient>,
     pub blobscan_client: Box<dyn CommonBlobscanClient>,
     pub provider: Box<dyn Provider<Ethereum>>,
@@ -64,43 +67,56 @@ impl Context {
         let client = reqwest::Client::builder()
             .timeout(Duration::from_secs(16))
             .build()?;
-        let provider = ProviderBuilder::new()
-            .network::<Ethereum>()
-            .connect_http(config.execution_node_base_url.parse()?);
+        let provider: Box<dyn Provider<Ethereum>> = Box::new(
+            ProviderBuilder::new()
+                .network::<Ethereum>()
+                .connect_http(config.execution_node_base_url.parse()?),
+        );
+        let beacon_client: Box<dyn CommonBeaconClient> = Box::new(BeaconClient::try_with_client(
+            client.clone(),
+            BeaconClientConfig {
+                base_url: config.beacon_api_base_url.clone(),
+                exp_backoff: exp_backoff.clone(),
+            },
+        )?);
+        let blobscan_client: Box<dyn CommonBlobscanClient> =
+            Box::new(BlobscanClient::try_with_client(
+                client,
+                BlobscanClientConfig {
+                    base_url: config.blobscan_api_base_url.clone(),
+                    secret_key: config.blobscan_secret_key.clone(),
+                    exp_backoff,
+                },
+            )?);
 
-        let ctx = Self {
+        let slots_per_epoch = Self::validate_clients_consistency(
+            provider.as_ref(),
+            beacon_client.as_ref(),
+            &config.network,
+        )
+        .await?;
+
+        Ok(Self {
             inner: Arc::new(ContextRef {
                 network: config.network,
+                slots_per_epoch,
                 syncing_settings: config.syncing_settings,
-                blobscan_client: Box::new(BlobscanClient::try_with_client(
-                    client.clone(),
-                    BlobscanClientConfig {
-                        base_url: config.blobscan_api_base_url.clone(),
-                        secret_key: config.blobscan_secret_key.clone(),
-                        exp_backoff: exp_backoff.clone(),
-                    },
-                )?),
-                beacon_client: Box::new(BeaconClient::try_with_client(
-                    client,
-                    BeaconClientConfig {
-                        base_url: config.beacon_api_base_url.clone(),
-                        exp_backoff,
-                    },
-                )?),
-                // Provider::<HttpProvider>::try_from(execution_node_endpoint)?
-                provider: Box::new(provider),
+                blobscan_client,
+                beacon_client,
+                provider,
             }),
-        };
-
-        ctx.validate_clients_consistency().await?;
-
-        Ok(ctx)
+        })
     }
 
-    async fn validate_clients_consistency(&self) -> AnyhowResult<()> {
-        let execution_chain_id = self.provider().get_chain_id().await?;
-        let consensus_spec = self.beacon_client().get_spec().await?;
-        let network = self.network();
+    /// Cross-checks the execution and consensus clients against the configured network
+    /// and returns the consensus `SLOTS_PER_EPOCH` value.
+    async fn validate_clients_consistency(
+        provider: &dyn Provider<Ethereum>,
+        beacon_client: &dyn CommonBeaconClient,
+        network: &Network,
+    ) -> AnyhowResult<u32> {
+        let execution_chain_id = provider.get_chain_id().await?;
+        let consensus_spec = beacon_client.get_spec().await?;
 
         match consensus_spec {
             Some(spec) => {
@@ -116,13 +132,15 @@ impl Context {
                         bail!("Environment network mismatch for '{p}': expected chain_id={}, got {} from execution client", network.chain_id, execution_chain_id);
                     }
                 }
-            }
-            None => {
-                return Err(anyhow!("No consensus spec found"));
-            }
-        };
 
-        Ok(())
+                if spec.slots_per_epoch == 0 {
+                    bail!("Consensus spec reported SLOTS_PER_EPOCH = 0");
+                }
+
+                Ok(spec.slots_per_epoch as u32)
+            }
+            None => Err(anyhow!("No consensus spec found")),
+        }
     }
 }
 
@@ -145,6 +163,10 @@ impl CommonContext for Context {
 
     fn network(&self) -> &Network {
         &self.inner.network
+    }
+
+    fn slots_per_epoch(&self) -> u32 {
+        self.inner.slots_per_epoch
     }
 }
 

--- a/src/slots_processor/mod.rs
+++ b/src/slots_processor/mod.rs
@@ -231,7 +231,8 @@ impl SlotsProcessor {
         }
 
         // Create entities to be indexed
-        let block_entity = Block::try_from((&execution_block, slot))?;
+        let block_entity =
+            Block::try_from((&execution_block, slot, self.context.slots_per_epoch()))?;
         let tx_entities = blob_txs
             .iter()
             .map(|tx| BlobscanTransaction::try_from((*tx, &execution_block)))


### PR DESCRIPTION
## What

Adds an `epoch` field to the block payload sent to the Blobscan `indexer/block-txs-blobs` (index) endpoint.

## Why / how

The beacon block response has no block-level `epoch` field — only `slot`. Epoch is a derived quantity: `epoch = slot / SLOTS_PER_EPOCH`.

Rather than hardcoding `/32` (incorrect for Gnosis/Chiado, which use 16 slots per epoch), `SLOTS_PER_EPOCH` is read from the consensus client's `/eth/v1/config/spec` endpoint — which the indexer already queries at startup for client-consistency validation. This keeps the beacon node authoritative across all supported networks and devnets.

## Changes

- `clients/beacon/types.rs` — read `SLOTS_PER_EPOCH` into the `Spec` struct.
- `context.rs` — build clients first, fetch the spec once (reused for validation + `slots_per_epoch`), store `slots_per_epoch` on the context, and expose it via `CommonContext::slots_per_epoch()`. Bails if the spec reports `0`.
- `clients/blobscan/types.rs` — add `epoch: u32` to the `Block` entity, computed in `TryFrom` as `slot / slots_per_epoch`.
- `slots_processor/mod.rs` — pass `slots_per_epoch` into `Block::try_from`.

## Notes

- The Blobscan API's index endpoint must accept the new `epoch` field for this to be consumed end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)